### PR TITLE
Compile pre-parsed AES-128 circuit

### DIFF
--- a/zkboo/CMakeLists.txt
+++ b/zkboo/CMakeLists.txt
@@ -19,7 +19,7 @@ include(${CMAKE_FOLDER}/cmake/emp-base.cmake)
 set(sources
     ../emp-tool/emp-tool/emp-tool.cpp
     ../emp-tool/emp-tool/circuits/files/bristol_fashion/Keccak_f.txt.cpp
-    ../emp-tool/emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp
+    ../emp-tool/emp-tool/circuits/files/bristol_fashion/aes_128.cpp
     )
 add_library(Base SHARED ${sources})
 


### PR DESCRIPTION
Smaller but still tangible improvement. Depends on my fork of emp-tool (which I'll probably try to upstream soon): [kdrag0n/emp-tool@preparsed-aes128 (commits)](https://github.com/kdrag0n/emp-tool/commits/preparsed-aes128)